### PR TITLE
Fix enter before <?php

### DIFF
--- a/config/mjml.php
+++ b/config/mjml.php
@@ -1,4 +1,3 @@
-
 <?php
 
 return [


### PR DESCRIPTION
My photos started to be wrong since a \n was being added in front of it. Narrowed down the culprit to this.