### PR TITLE
Fixed rendering of MJML in Laravel 9

### DIFF
--- a/src/InteractsWithMjml.php
+++ b/src/InteractsWithMjml.php
@@ -10,18 +10,13 @@ use Illuminate\Support\HtmlString;
 trait InteractsWithMjml
 {
     /**
-     * The MJML template for the message (if applicable).
-     */
-    public string $mjml;
-
-    /**
      * Set the MJML template for the message.
      *
      * @retur self
      */
     public function mjml(string $view, array $data = []): self
     {
-        $this->mjml = $view;
+        $this->view = $view;
         $this->viewData = array_merge($this->viewData, $data);
 
         return $this;
@@ -61,6 +56,6 @@ trait InteractsWithMjml
      */
     protected function renderMjmlView(): string
     {
-        return app(Mjml::class, ['view' => $this->mjml, 'data' => $this->viewData])->render();
+        return app(Mjml::class, ['view' => $this->view, 'data' => $this->viewData])->render();
     }
 }

--- a/src/Mail/Messages/MjmlMessage.php
+++ b/src/Mail/Messages/MjmlMessage.php
@@ -11,10 +11,6 @@ class MjmlMessage extends MailMessage
 
     public function render(): string
     {
-        if (isset($this->mjml)) {
-            return $this->renderMjml();
-        }
-
-        return parent::render();
+        return $this->renderMjml();
     }
 }


### PR DESCRIPTION
I don't know if this is prevalent in other versions, but on Laravel 9 the way the messages are rendered, it only checks for view or markdown. If view is not specified, the default rendering engine goes to Markdown rendering and will render the default notification.

So, to do this we simply need to set the view property. However, I also removed some of the checks as - if you're implementing MJML message and using that class, there's really no need to check to see if mjml is set - it should want to render MJML. If you want to use just normal blade, then use the normal MailMessage class.